### PR TITLE
fix: invalid event dates crash and PWA install toast warning

### DIFF
--- a/apps/vite/src/components/InstallBtn.tsx
+++ b/apps/vite/src/components/InstallBtn.tsx
@@ -49,51 +49,57 @@ const InstallPWA = ({
     promptInstall.prompt()
   }
 
-  if (!supportsPWA) {
-    toast.dismiss()
-    return null
-  }
-  // toast.dismiss();
-  toast.custom(
-    (t) => (
-      <div
-        className={`${
-          t.visible ? "animate-enter" : "animate-leave"
-        } pointer-events-auto flex w-full max-w-md rounded-md border bg-white shadow-lg ring-1 ring-black ring-opacity-5 dark:border-gray-600 dark:bg-gray-800`}
-      >
-        <div className="w-0 flex-1 p-4">
-          <div className="flex items-start">
-            <div className="flex-shrink-0 pt-0.5">
-              <img
-                className="h-10 w-10 rounded-full"
-                src="/icons/icon-96x96.png"
-                alt=""
-              />
-            </div>
-            <div className="ml-3 flex-1">
-              <p className="text-sm font-medium text-gray-900 dark:text-gray-200">
-                App Installation Available.
-              </p>
-              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                ~150KB, works offline.
-              </p>
+  useEffect(() => {
+    if (!supportsPWA) {
+      toast.dismiss()
+      return
+    }
+    // toast.dismiss();
+    toast.custom(
+      (t) => (
+        <div
+          className={`${
+            t.visible ? "animate-enter" : "animate-leave"
+          } pointer-events-auto flex w-full max-w-md rounded-md border bg-white shadow-lg ring-1 ring-black ring-opacity-5 dark:border-gray-600 dark:bg-gray-800`}
+        >
+          <div className="w-0 flex-1 p-4">
+            <div className="flex items-start">
+              <div className="flex-shrink-0 pt-0.5">
+                <img
+                  className="h-10 w-10 rounded-full"
+                  src="/icons/icon-96x96.png"
+                  alt=""
+                />
+              </div>
+              <div className="ml-3 flex-1">
+                <p className="text-sm font-medium text-gray-900 dark:text-gray-200">
+                  App Installation Available.
+                </p>
+                <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                  ~150KB, works offline.
+                </p>
+              </div>
             </div>
           </div>
+          <div className="flex border-l border-gray-200">
+            <button
+              onClick={onClick}
+              className="flex w-full items-center justify-center rounded-none rounded-r-lg border border-transparent p-4 text-sm font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:text-white"
+            >
+              Install
+            </button>
+          </div>
         </div>
-        <div className="flex border-l border-gray-200">
-          <button
-            onClick={onClick}
-            className="flex w-full items-center justify-center rounded-none rounded-r-lg border border-transparent p-4 text-sm font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:text-white"
-          >
-            Install
-          </button>
-        </div>
-      </div>
-    ),
-    {
-      id: "install",
-    }
-  )
+      ),
+      {
+        id: "install",
+      }
+    )
+  }, [supportsPWA, promptInstall])
+
+  if (!supportsPWA) {
+    return null
+  }
   return <div onClick={onClick}>{children}</div>
 }
 

--- a/apps/vite/src/helper/dates.ts
+++ b/apps/vite/src/helper/dates.ts
@@ -184,7 +184,7 @@ export function relativeTimeFromDates(
   isNepaliLanguage = false,
   pivot = new Date()
 ): string {
-  if (!relative) return ""
+  if (!relative || Number.isNaN(relative.getTime())) return ""
 
   // Calculate the difference in days between the relative date and the current date
   const dayInMillis = 24 * 60 * 60 * 1000 // Milliseconds in a day
@@ -193,6 +193,8 @@ export function relativeTimeFromDates(
   const relativeDay = Math.round(
     (relative.getTime() - todayStart) / dayInMillis
   )
+
+  if (!Number.isFinite(relativeDay)) return ""
 
   // Use the relativeTimeFromElapsed function to get the language-sensitive relative time message
   return relativeTimeFromElapsed(relativeDay, isNepaliLanguage)


### PR DESCRIPTION
# Summary
- Guard `relativeTimeFromDates` against invalid dates so `UpcomingEvent` no longer crashes when `enDate` is empty/invalid
- Move PWA install `toast` calls into `useEffect` so React doesn’t warn about updating state while rendering `InstallPWA`
## Test plan
- [ ] Open calendar page with upcoming events — list renders without crashing
- [ ] Confirm relative time still shows for valid event dates
- [ ] Trigger / simulate PWA install prompt — no “Cannot update a component while rendering InstallPWA” warning
- [ ] Install toast still appears when the browser supports PWA install


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the progressive web app installation prompt so it appears and dismisses reliably based on installation support.
  * Prevented invalid or unavailable dates from producing incorrect relative-time displays.
  * Added safeguards to keep date-related messaging blank when a valid time value cannot be calculated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->